### PR TITLE
fix(orbitdb): Added cache to prevent double-processing of duplicate replication events

### DIFF
--- a/lib/orbitdb.js
+++ b/lib/orbitdb.js
@@ -41,7 +41,13 @@ class OrbitDB {
     this.peers = undefined // placeholder for an instance of the Peers lib.
     this.encrypt = undefined // placeholder for encryption lib
 
+    // Private log handler to send decrypted messages to.
     this.privateLog = orbitConfig.privateLog
+
+    // Cache to store hashes of processed messages. Used to prevent duplicate
+    // processing.
+    this.msgCache = []
+    this.MSG_CACHE_SIZE = 10
 
     _this = this
   }
@@ -112,24 +118,52 @@ class OrbitDB {
   // Event handler for when a peer publishes a message to this nodes Receive DB.
   async handleReplicationEvent (orbitdbId) {
     try {
-      // Get the most recent entry.
-      const result = _this.db
-        .iterator({ limit: 1 })
-        .collect()
-        .map(e => e.payload.value)
-      // console.log('result: ', result)
+      const newData = _this.db.iterator({ limit: 1 }).collect()
+      // console.log(`newData: ${JSON.stringify(newData, null, 2)}`)
 
-      // ToDo: Implement a FIFO array of the last 10 hashes. Skip processing if
-      // the hash of the incoming message matches (has already been processed).
-      // I'm noticing some duplicate entries.
+      const hash = newData[0].hash
 
-      const decryptedStr = await _this.encrypt.decryptMsg(result[0].data)
-      // console.log('decryptedStr: ', decryptedStr)
+      const alreadyProcessed = _this._checkIfAlreadyProcessed(hash)
 
-      _this.privateLog(decryptedStr, result[0].from)
+      // Quietly exit if the hash has already been processed. (This eliminates
+      // double processing the same entry).
+      if (!alreadyProcessed) {
+        // Get the most recent entry.
+        const result = newData.map(e => e.payload.value)
+        // console.log('result: ', result)
+
+        // ToDo: Implement a FIFO array of the last 10 hashes. Skip processing if
+        // the hash of the incoming message matches (has already been processed).
+        // I'm noticing some duplicate entries.
+
+        const decryptedStr = await _this.encrypt.decryptMsg(result[0].data)
+        // console.log('decryptedStr: ', decryptedStr)
+
+        _this.privateLog(decryptedStr, result[0].from)
+      }
     } catch (err) {
       console.error('Error in orbitdb.js/handleReplicationEvent(): ', err)
     }
+  }
+
+  // Checks the hash to see if the message has already been processed. Returns
+  // true if the hash exists in the list of processed messages.
+  _checkIfAlreadyProcessed (hash) {
+    // Check if the hash is in the array of already processed message.
+    const alreadyProcessed = this.msgCache.includes(hash)
+
+    // Update the msgCache if this is a new message.
+    if (!alreadyProcessed) {
+      // Add the hash to the array.
+      this.msgCache.push(hash)
+
+      // If the array is at its max size, then remove the oldest element.
+      if (this.msgCache.length > this.MSG_CACHE_SIZE) {
+        this.msgCache.shift()
+      }
+    }
+
+    return alreadyProcessed
   }
 
   // Publish a string of text to another peers OrbitDB recieve database.

--- a/lib/orbitdb.js
+++ b/lib/orbitdb.js
@@ -119,6 +119,10 @@ class OrbitDB {
         .map(e => e.payload.value)
       // console.log('result: ', result)
 
+      // ToDo: Implement a FIFO array of the last 10 hashes. Skip processing if
+      // the hash of the incoming message matches (has already been processed).
+      // I'm noticing some duplicate entries.
+
       const decryptedStr = await _this.encrypt.decryptMsg(result[0].data)
       // console.log('decryptedStr: ', decryptedStr)
 

--- a/test/unit/a07-orbitdb-unit.js
+++ b/test/unit/a07-orbitdb-unit.js
@@ -136,6 +136,37 @@ describe('#orbitdb', () => {
     })
   })
 
+  describe('#_checkIfAlreadyProcessed', () => {
+    it('should return false for a new message', () => {
+      const hash = 'abc'
+
+      const result = uut._checkIfAlreadyProcessed(hash)
+
+      assert.equal(result, false)
+    })
+
+    it('should return true for duplicate hash', () => {
+      const hash = 'abc'
+
+      uut._checkIfAlreadyProcessed(hash)
+
+      const result = uut._checkIfAlreadyProcessed(hash)
+
+      assert.equal(result, true)
+    })
+
+    it('should remove old entries as new entries are processed', () => {
+      // Force cache to only be 2 elements.
+      uut.MSG_CACHE_SIZE = 2
+
+      uut._checkIfAlreadyProcessed('abc')
+      uut._checkIfAlreadyProcessed('def')
+      uut._checkIfAlreadyProcessed('geh')
+
+      assert.equal(uut.msgCache.includes('abc'), false)
+    })
+  })
+
   describe('#handleReplicationEvent', () => {
     it('should decrypt an incoming message an pass it to the private log', async () => {
       // Mock dependencies
@@ -144,6 +175,7 @@ describe('#orbitdb', () => {
       }
       sandbox.stub(uut.encrypt, 'decryptMsg').resolves('decrypted message')
 
+      // Mock the database.
       uut.db = mockData.mockEventLog
       // console.log('uut.db: ', uut.db)
 


### PR DESCRIPTION
Sometimes a new message published to the DB will trigger two 'replication' events. The cache added in this PR prevents duplicate processing, by checking to see if new entries have already been processed.